### PR TITLE
Changed default keyword from 'brave' to '@brave'

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,7 @@
   "chrome_settings_overrides": {
     "search_provider": {
       "name": "Brave search",
-      "keyword": "brave",
+      "keyword": "@brave",
       "favicon_url": "https://cdn.search.brave.com/serp/v1/static/brand/9b3cd14668935362449eebb1854f575091a1169bf51aba6a8c17b39f64a9d07e-favicon-16x16.png",
       "search_url": "https://search.brave.com/search?q={searchTerms}"
     }


### PR DESCRIPTION
I wanted to use Brave as my default search engine, and to test it out, I typed "brave search" in my address bar, and I got Brave Search results (success!) for the search "search", not for "brave search" as expected (not so successful!).  After a moment, I realized that "brave" was the default keyword for this search.  Then I realized it's not possible to change that (you can add another keyword, but you can't disable, as far as I can tell, the default).  So in order to search for things that start with the word "brave", you have to type "brave" twice, which is not a great experience.  All my built-in search engines seem to have default keywords that start with "@", so that seems like a good default for this as well.